### PR TITLE
Made Proxima no longer visible from Sol

### DIFF
--- a/src/main/resources/assets/stellarview/stellarview/celestials/star/milky_way/alpha_centauri/proxima_centauri.json
+++ b/src/main/resources/assets/stellarview/stellarview/celestials/star/milky_way/alpha_centauri/proxima_centauri.json
@@ -10,7 +10,7 @@
 			"blend": true,
 			"size": 692146201.5,
 			"min_size": 0.3,
-			"clamp_at_min_size": true,
+			"clamp_at_min_size": false,
 			"rotation": 12,
 			"uv": { "flip_uv": false }
 		}


### PR DESCRIPTION
Its apparent magnitude is 11.13, and the maximum magnitude humans can see without aid is around 6. Shouldn't be visible. Maybe. Possibly.